### PR TITLE
Implement hierarchical states

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,20 @@ func main() {
 
 	currentState := lightSwitchStateMachine.Current()
 	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
+	fmt.Printf("The light switch is off: %v\n", currentState.Matches(OffState))         // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
+	fmt.Printf("The light switch is on: %v\n", stateAfterFirstToggle.Matches(OnState))                          // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
+	fmt.Printf("Is the light switch on? %v\n", stateAfterSecondToggle.Matches(OnState))                           // false
+
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ const (
 )
 
 func main() {
-	lightSwitchStateMachine := brainy.Machine{
+	lightSwitchStateMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
-			OnState: brainy.StateNode{
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `on` state")
@@ -53,7 +53,7 @@ func main() {
 				},
 			},
 
-			OffState: brainy.StateNode{
+			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `off` state")
@@ -76,21 +76,24 @@ func main() {
 				},
 			},
 		},
+	})
+	if err != nil {
+		fmt.Printf("invalid state machine declaration: %s\n", err)
+		return
 	}
-	lightSwitchStateMachine.Init()
 
 	currentState := lightSwitchStateMachine.Current()
-	fmt.Printf("The current state of the state machine is: %s\n", currentState) // off
+	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle) // on
+	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle) // off
+	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
 }
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,16 +84,20 @@ func main() {
 
 	currentState := lightSwitchStateMachine.Current()
 	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
+	fmt.Printf("The light switch is off: %v\n", currentState.Matches(OffState))         // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
+	fmt.Printf("The light switch is on: %v\n", stateAfterFirstToggle.Matches(OnState))                          // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
+	fmt.Printf("Is the light switch on? %v\n", stateAfterSecondToggle.Matches(OnState))                           // false
+
 }
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,11 +26,11 @@ const (
 )
 
 func main() {
-	lightSwitchStateMachine := brainy.Machine{
+	lightSwitchStateMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
-			OnState: brainy.StateNode{
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `on` state")
@@ -53,7 +53,7 @@ func main() {
 				},
 			},
 
-			OffState: brainy.StateNode{
+			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `off` state")
@@ -76,21 +76,24 @@ func main() {
 				},
 			},
 		},
+	})
+	if err != nil {
+		fmt.Printf("invalid state machine declaration: %s\n", err)
+		return
 	}
-	lightSwitchStateMachine.Init()
 
 	currentState := lightSwitchStateMachine.Current()
-	fmt.Printf("The current state of the state machine is: %s\n", currentState) // off
+	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle) // on
+	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle) // off
+	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
 }
 
 ```

--- a/examples/on-off/main.go
+++ b/examples/on-off/main.go
@@ -15,11 +15,11 @@ const (
 )
 
 func main() {
-	lightSwitchStateMachine := brainy.Machine{
+	lightSwitchStateMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
-			OnState: brainy.StateNode{
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `on` state")
@@ -42,7 +42,7 @@ func main() {
 				},
 			},
 
-			OffState: brainy.StateNode{
+			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
 					func(c brainy.Context, e brainy.Event) error {
 						fmt.Println("Reached `off` state")
@@ -65,21 +65,24 @@ func main() {
 				},
 			},
 		},
+	})
+	if err != nil {
+		fmt.Printf("invalid state machine declaration: %s\n", err)
+		return
 	}
-	lightSwitchStateMachine.Init()
 
 	currentState := lightSwitchStateMachine.Current()
-	fmt.Printf("The current state of the state machine is: %s\n", currentState) // off
+	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle) // on
+	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
-	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle) // off
+	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
 }
 
 // @@@SNIPEND

--- a/examples/on-off/main.go
+++ b/examples/on-off/main.go
@@ -73,16 +73,20 @@ func main() {
 
 	currentState := lightSwitchStateMachine.Current()
 	fmt.Printf("The current state of the state machine is: %s\n", currentState.Value()) // (machine).off
+	fmt.Printf("The light switch is off: %v\n", currentState.Matches(OffState))         // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterFirstToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the first toogle is: %s\n", stateAfterFirstToggle.Value()) // (machine).on
+	fmt.Printf("The light switch is on: %v\n", stateAfterFirstToggle.Matches(OnState))                          // true
 
 	lightSwitchStateMachine.Send(ToggleEvent)
 
 	stateAfterSecondToggle := lightSwitchStateMachine.Current()
 	fmt.Printf("The state of the state machine after the second toogle is: %s\n", stateAfterSecondToggle.Value()) // (machine).off
+	fmt.Printf("Is the light switch on? %v\n", stateAfterSecondToggle.Matches(OnState))                           // false
+
 }
 
 // @@@SNIPEND

--- a/machine.go
+++ b/machine.go
@@ -368,15 +368,12 @@ func (s *StateNode) executeOnEntryActions(c Context, e Event) error {
 
 	stateNodeToEntry := s
 
-	for {
-		if onEntryActions := s.OnEntry; onEntryActions != nil {
+	for stateNodeToEntry != nil {
+		if onEntryActions := stateNodeToEntry.OnEntry; onEntryActions != nil {
 			actionsToCall = append(actionsToCall, onEntryActions...)
 		}
 
 		// Be sure to execute the OnEntry actions of the root state node, which has a parentStateNode of nil.
-		if stateNodeToEntry == nil {
-			break
-		}
 
 		stateNodeToEntry = stateNodeToEntry.parentStateNode
 	}

--- a/machine.go
+++ b/machine.go
@@ -459,8 +459,7 @@ func (s *StateNode) validate(m *Machine) error {
 				}
 
 				if _, hasTarget := s.getTarget(target); !hasTarget {
-					// TODO: improve error
-					return errors.New("Invalid transition")
+					return ErrInvalidTransitionNotImplemented
 				}
 			}
 		}

--- a/machine.go
+++ b/machine.go
@@ -3,6 +3,7 @@ package brainy
 import (
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -25,6 +26,7 @@ var (
 	//  	},
 	//  }
 	ErrInvalidTransitionInvalidCurrentState = errors.New("current state is unexpected")
+	ErrBlankInitialStateForCompoundState    = errors.New("expected an initial state for a compound state node")
 	// ErrInvalidTransitionFinalState is returned by Send method when the current state of the state
 	// machine does not have any event handler.
 	ErrInvalidTransitionFinalState = errors.New("final state reached")
@@ -34,6 +36,14 @@ var (
 	// Transitions validity is checked when .Init() method is called.
 	ErrInvalidTransitionNotImplemented = errors.New("transition not implemented")
 )
+
+type ErrInvalidInitialState struct {
+	InvalidInitialState StateType
+}
+
+func (err *ErrInvalidInitialState) Error() string {
+	return "initial state references an invalid state node: " + string(err.InvalidInitialState)
+}
 
 // ErrInvalidTransition means a transition could not be performed, holding the reason why.
 type ErrInvalidTransition struct {
@@ -105,10 +115,65 @@ func (s StateType) transitions() []Transition {
 	}
 }
 
+func (s StateType) target() []StateType {
+	return []StateType{
+		s,
+	}
+}
+
+func (s StateType) String() string {
+	return string(s)
+}
+
 // NoneState describes a transition to a state itself.
 // As the zero value of a string is an empty string, it allows us to let the Target field
 // blank.
 const NoneState StateType = ""
+
+type CompoundTarget map[StateType]Targeter
+
+func (c CompoundTarget) transitions() []Transition {
+	return []Transition{
+		{
+			Target: c,
+		},
+	}
+}
+
+func (c CompoundTarget) target() []StateType {
+	states := make([]StateType, 0)
+
+	parentStateIndex := 0
+	for parentState, nodes := range c {
+		// Currently we only want to handle transitions to a single branch of states.
+		if parentStateIndex > 0 {
+			break
+		}
+
+		states = append(states, parentState)
+		states = append(states, nodes.target()...)
+
+		parentStateIndex++
+	}
+
+	return removeDuplicatesFromStateTypeSlice(states)
+}
+
+func (c CompoundTarget) String() string {
+	targets := c.target()
+	targetsAsString := make([]string, 0, len(targets))
+
+	for _, target := range targets {
+		targetsAsString = append(targetsAsString, target.String())
+	}
+
+	return strings.Join(targetsAsString, ".")
+}
+
+type Targeter interface {
+	target() []StateType
+	String() string
+}
 
 // EventType is the base of an event.
 // EventType implements the Event interface, so that we can send an EventType to a state machine.
@@ -198,7 +263,7 @@ type Cond func(Context, Event) bool
 // as currently there is no built-in assign action in brainy.
 type Transition struct {
 	Cond    Cond
-	Target  StateType
+	Target  Targeter
 	Actions Actions
 }
 
@@ -210,6 +275,21 @@ func (t Transition) transitions() []Transition {
 // We can use as values a single Transition as well as a Transitions slice.
 type Events map[EventType]Transitioner
 
+// JoinStatesIDs takes an unlimited number of state types and returns
+// them as a concatenated string, each of them separed by a "." character.
+func JoinStatesIDs(statesIDs ...StateType) string {
+	concatenatedIDs := ""
+
+	for index, id := range statesIDs {
+		concatenatedIDs += id.String()
+		if index < len(statesIDs)-1 {
+			concatenatedIDs += "."
+		}
+	}
+
+	return concatenatedIDs
+}
+
 // A StateNode is a node of the state machine.
 // It has a map of Events to listen to, OnEntry actions to run when the state is entered and
 // OnExit actions to run when the state is exited.
@@ -218,6 +298,8 @@ type Events map[EventType]Transitioner
 // When no events are specified, the state node is of *final* type, which means once reached, the state
 // machine can not be transitioned anymore.
 type StateNode struct {
+	id string
+
 	Context Context
 
 	Initial StateType
@@ -228,41 +310,148 @@ type StateNode struct {
 	OnExit  Actions
 
 	On Events
+
+	parentStateNode *StateNode
 }
 
-// A StateNodes holds all state nodes of a machine.
-type StateNodes map[StateType]StateNode
+func (s *StateNode) Value() string {
+	return s.id
+}
 
-// NewMachine takes a StateNode configuration and returns a Machine if one could be created from the given configuration.
-// The configuration is validated so that impossible transitions are not possible at runtime.
-// If the state machine could not be created, the validation error is returned.
-func NewMachine(config StateNode) (*Machine, error) {
-	machine := &Machine{
-		StateNode: config,
+func (s *StateNode) setChildrenStateNodesIDs(parentStateNodeID string) {
+	for childStateNodeName, childStateNode := range s.States {
+		childStateNode.id = parentStateNodeID + "." + childStateNodeName.String()
+
+		if childStateNode.isCompound() {
+			childStateNode.setChildrenStateNodesIDs(childStateNode.id)
+		}
 	}
-	if err := machine.init(); err != nil {
-		return nil, err
+}
+
+func (s StateNode) isAtomic() bool {
+	return s.States == nil || len(s.States) == 0
+}
+
+func (s StateNode) isCompound() bool {
+	return !s.isAtomic()
+}
+
+func (s *StateNode) resolveMostNestedInitialStateNode() *StateNode {
+	if !s.isCompound() {
+		return s
 	}
 
-	return machine, nil
+	initialStateNode := s.States[s.Initial]
+	return initialStateNode.resolveMostNestedInitialStateNode()
 }
 
-// A Machine is a simple finite state machine.
-// State machines should be instanciated through NewMachine function, that will validate state nodes configuration.
-//
-// The long-term objective of this library is to have a Golang implementation of state charts as defined by the SCXML specification.
-type Machine struct {
-	StateNode
+func (s *StateNode) getTarget(t Targeter) (*StateNode, bool) {
+	targetID := t.String()
 
-	previous StateType
-	current  StateType
+	for _, childStateNode := range s.States {
+		if stateNodeIDEndsWithTargetID := strings.HasSuffix(childStateNode.id, targetID); stateNodeIDEndsWithTargetID {
+			return childStateNode.resolveMostNestedInitialStateNode(), true
+		}
 
-	lock sync.Mutex
+		if matchingChildStateNode, ok := childStateNode.getTarget(t); ok {
+			return matchingChildStateNode.resolveMostNestedInitialStateNode(), true
+		}
+	}
+
+	return nil, false
 }
 
-// Validate ensures all transitions targets are valid states.
-func (machine *Machine) validate() error {
-	for _, stateNode := range machine.States {
+func (s *StateNode) executeOnEntryActions(c Context, e Event) error {
+	actionsToCall := make([]Action, 0)
+
+	stateNodeToEntry := s
+
+	for {
+		if onEntryActions := s.OnEntry; onEntryActions != nil {
+			actionsToCall = append(actionsToCall, onEntryActions...)
+		}
+
+		// Be sure to execute the OnEntry actions of the root state node, which has a parentStateNode of nil.
+		if stateNodeToEntry == nil {
+			break
+		}
+
+		stateNodeToEntry = stateNodeToEntry.parentStateNode
+	}
+
+	countOfActions := len(actionsToCall)
+	actionsToCallInReverseOrder := make([]Action, countOfActions)
+
+	for index, action := range actionsToCall {
+		actionsToCallInReverseOrder[countOfActions-index-1] = action
+	}
+
+	for index, action := range actionsToCallInReverseOrder {
+		if err := action(c, e); err != nil {
+			return &ErrAction{
+				Type: onEntryActionType,
+				ID:   index,
+				Err:  err,
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *StateNode) executeOnExitActions(c Context, e Event) error {
+	stateNodeToExit := s
+
+	for {
+		if onExitActions := s.OnExit; onExitActions != nil {
+			for index, action := range onExitActions {
+				if err := action(c, e); err != nil {
+					return &ErrAction{
+						Type: onExitActionType,
+						ID:   index,
+						Err:  err,
+					}
+				}
+			}
+		}
+
+		// Be sure to execute the OnEntry actions of the root state node, which has a parentStateNode of nil.
+		if stateNodeToExit == nil {
+			break
+		}
+
+		stateNodeToExit = stateNodeToExit.parentStateNode
+	}
+
+	return nil
+}
+
+func (s *StateNode) validate(m *Machine) error {
+	if s.isAtomic() {
+		return nil
+	}
+
+	if s.Initial == NoneState {
+		return ErrBlankInitialStateForCompoundState
+	}
+
+	if _, ok := s.States[s.Initial]; !ok {
+		return &ErrInvalidInitialState{
+			InvalidInitialState: s.Initial,
+		}
+	}
+
+	for _, stateNode := range s.States {
+		// Set the parentStateNode of each state node
+		stateNode.parentStateNode = s
+
+		// Recursively validate children states
+		if stateNode.isCompound() {
+			if err := stateNode.validate(m); err != nil {
+				return err
+			}
+		}
+
 		handlers := stateNode.On
 		if handlers == nil {
 			continue
@@ -277,14 +466,72 @@ func (machine *Machine) validate() error {
 					continue
 				}
 
-				if _, ok := machine.States[target]; !ok {
-					return ErrInvalidTransitionNotImplemented
+				if _, hasTarget := s.getTarget(target); !hasTarget {
+					// TODO: improve error
+					return errors.New("Invalid transition")
 				}
 			}
 		}
+
 	}
 
 	return nil
+}
+
+// A StateNodes holds all state nodes of a machine.
+type StateNodes map[StateType]*StateNode
+
+// NewMachine takes a StateNode configuration and returns a Machine if one could be created from the given configuration.
+// The configuration is validated so that impossible transitions are not possible at runtime.
+// If the state machine could not be created, the validation error is returned.
+func NewMachine(config StateNode) (*Machine, error) {
+	machine := &Machine{
+		StateNode: &config,
+	}
+	if err := machine.init(); err != nil {
+		return nil, err
+	}
+
+	return machine, nil
+}
+
+// A Machine is a simple finite state machine.
+// State machines should be instanciated through NewMachine function, that will validate state nodes configuration.
+//
+// The long-term objective of this library is to have a Golang implementation of state charts as defined by the SCXML specification.
+type Machine struct {
+	ID string
+
+	StateNode *StateNode
+
+	previous *StateNode
+	current  *StateNode
+
+	lock sync.Mutex
+}
+
+func (machine *Machine) setStateNodesIDs() {
+	rootID := machine.ID
+	if rootID == "" {
+		rootID = "(machine)"
+	}
+
+	machine.StateNode.id = rootID
+
+	for stateNodeName, stateNode := range machine.StateNode.States {
+		stateNode.id = machine.StateNode.id + "." + stateNodeName.String()
+
+		stateNode.setChildrenStateNodesIDs(stateNode.id)
+	}
+}
+
+// Validate ensures all transitions targets are valid states.
+func (machine *Machine) validate() error {
+	machine.setStateNodesIDs()
+
+	err := machine.StateNode.validate(machine)
+
+	return err
 }
 
 // Init initializes the machine and validates transitions target state.
@@ -293,13 +540,13 @@ func (machine *Machine) init() error {
 		return err
 	}
 
-	machine.current = machine.Initial
+	machine.current = machine.StateNode.resolveMostNestedInitialStateNode()
 
 	return nil
 }
 
 // Previous returns previous state.
-func (machine *Machine) Previous() StateType {
+func (machine *Machine) Previous() *StateNode {
 	machine.lock.Lock()
 	defer machine.lock.Unlock()
 
@@ -307,7 +554,7 @@ func (machine *Machine) Previous() StateType {
 }
 
 // Current returns current state.
-func (machine *Machine) Current() StateType {
+func (machine *Machine) Current() *StateNode {
 	machine.lock.Lock()
 	defer machine.lock.Unlock()
 
@@ -315,92 +562,69 @@ func (machine *Machine) Current() StateType {
 }
 
 // UnsafeCurrent returns current state without taking care of active lock.
-func (machine *Machine) UnsafeCurrent() StateType {
+func (machine *Machine) UnsafeCurrent() *StateNode {
 	return machine.current
-}
-
-func (machine *Machine) getTransitions(event EventType) ([]Transition, error) {
-	currentState, ok := machine.States[machine.current]
-	if !ok {
-		return nil, &ErrInvalidTransition{
-			Err: ErrInvalidTransitionInvalidCurrentState,
-		}
-	}
-
-	if currentState.On == nil {
-		return nil, &ErrInvalidTransition{
-			Err: ErrInvalidTransitionFinalState,
-		}
-	}
-
-	transitions, ok := currentState.On[event]
-	if !ok {
-		return nil, &ErrInvalidTransition{
-			Err: ErrInvalidTransitionNotImplemented,
-		}
-	}
-
-	return transitions.transitions(), nil
 }
 
 // Send an event to the state machine.
 // Returns the new state and an error if one occured, or nil.
-func (machine *Machine) Send(event Event) (StateType, error) {
+func (machine *Machine) Send(event Event) (*StateNode, error) {
 	machine.lock.Lock()
 	defer machine.lock.Unlock()
 
 	eventType := event.eventType()
 
-	transitions, err := machine.getTransitions(eventType)
-	if err != nil {
-		return machine.current, &ErrTransition{
-			Event: eventType,
-			Err:   err,
-		}
-	}
+	stateNode := machine.current
 
-	for _, transition := range transitions {
-		shouldCommitTransition := true
-		if cond := transition.Cond; cond != nil {
-			shouldCommitTransition = cond(machine.Context, event)
-		}
-
-		if !shouldCommitTransition {
+	for stateNode != nil {
+		handlers := stateNode.On
+		if handlers == nil {
+			stateNode = stateNode.parentStateNode
 			continue
 		}
 
-		currentStateNode := machine.States[machine.current]
-		if onExitActions := currentStateNode.OnExit; onExitActions != nil {
-			for index, action := range onExitActions {
-				if err := action(machine.Context, event); err != nil {
-					return machine.current, &ErrAction{
-						Type: onExitActionType,
-						ID:   index,
-						Err:  err,
-					}
-				}
-			}
+		eventHandler := handlers[eventType]
+		if eventHandler == nil {
+			stateNode = stateNode.parentStateNode
+			continue
 		}
+		transitions := eventHandler.transitions()
 
-		if actions := transition.Actions; actions != nil {
-			for index, action := range actions {
-				if err := action(machine.Context, event); err != nil {
-					return machine.current, &ErrAction{
-						Type: transitionActionActionType,
-						ID:   index,
-						Err:  err,
-					}
-				}
+		for _, transition := range transitions {
+			shouldCommitTransition := true
+			if cond := transition.Cond; cond != nil {
+				shouldCommitTransition = cond(machine.StateNode.Context, event)
 			}
-		}
 
-		if target := transition.Target; target != NoneState {
-			nextStateNode := machine.States[target]
-			if onEntryActions := nextStateNode.OnEntry; onEntryActions != nil {
-				for index, action := range onEntryActions {
-					if err := action(machine.Context, event); err != nil {
+			if !shouldCommitTransition {
+				continue
+			}
+
+			var stateNodeToEnter *StateNode = nil
+			if target := transition.Target; target != NoneState {
+				// Get parent node to be able to target sibbling state nodes.
+				parentStateNode := stateNode.parentStateNode
+				if parentStateNode == nil {
+					return machine.current, errors.New("parent state node is nil")
+				}
+
+				resolvedTargetStateNode, ok := parentStateNode.getTarget(target)
+				if !ok {
+					return machine.current, errors.New("could not resolve target")
+				}
+
+				stateNodeToEnter = resolvedTargetStateNode
+			}
+
+			if err := machine.current.executeOnExitActions(machine.StateNode.Context, event); err != nil {
+				return machine.current, err
+			}
+
+			if actions := transition.Actions; actions != nil {
+				for index, action := range actions {
+					if err := action(machine.StateNode.Context, event); err != nil {
 						return machine.current, &ErrAction{
-							Type: onEntryActionType,
+							Type: transitionActionActionType,
 							ID:   index,
 							Err:  err,
 						}
@@ -409,11 +633,35 @@ func (machine *Machine) Send(event Event) (StateType, error) {
 			}
 
 			machine.previous = machine.current
-			machine.current = target
+			machine.current = stateNodeToEnter
+
+			if err := machine.current.executeOnEntryActions(machine.StateNode.Context, event); err != nil {
+				return machine.current, err
+			}
+
+			return machine.current, nil
 		}
 
-		break
+		stateNode = stateNode.parentStateNode
 	}
 
-	return machine.current, nil
+	return machine.current, ErrInvalidTransitionNotImplemented
+}
+
+func removeDuplicatesFromStateTypeSlice(s []StateType) []StateType {
+	encounteredKeys := make(map[StateType]bool)
+	uniqueValues := make([]StateType, 0, len(s))
+
+	for _, value := range s {
+		_, ok := encounteredKeys[value]
+		if ok == true {
+			continue
+		}
+
+		uniqueValues = append(uniqueValues, value)
+
+		encounteredKeys[value] = true
+	}
+
+	return uniqueValues
 }

--- a/machine.go
+++ b/machine.go
@@ -602,7 +602,7 @@ func (machine *Machine) Send(event Event) (*StateNode, error) {
 				continue
 			}
 
-			var stateNodeToEnter *StateNode = nil
+			var stateNodeToEnter *StateNode = machine.current
 			if target := transition.Target; target != NoneState {
 				// Get parent node to be able to target sibbling state nodes.
 				parentStateNode := stateNode.parentStateNode

--- a/machine.go
+++ b/machine.go
@@ -627,12 +627,12 @@ func (machine *Machine) Send(event Event) (*StateNode, error) {
 				}
 			}
 
-			machine.previous = machine.current
-			machine.current = stateNodeToEnter
-
-			if err := machine.current.executeOnEntryActions(machine.StateNode.Context, event); err != nil {
+			if err := stateNodeToEnter.executeOnEntryActions(machine.StateNode.Context, event); err != nil {
 				return machine.current, err
 			}
+
+			machine.previous = machine.current
+			machine.current = stateNodeToEnter
 
 			return machine.current, nil
 		}

--- a/machine.go
+++ b/machine.go
@@ -183,6 +183,8 @@ func (e EventType) eventType() EventType {
 	return e
 }
 
+const InitialTransitionEventType EventType = "_INITIAL_TRANSITION"
+
 // Context holds data passed to actions and guards functions.
 // It can contain what user wants.
 type Context interface{}
@@ -541,6 +543,9 @@ func (machine *Machine) init() error {
 	}
 
 	machine.current = machine.StateNode.resolveMostNestedInitialStateNode()
+	if err := machine.current.executeOnEntryActions(machine.current.Context, InitialTransitionEventType); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/machine.go
+++ b/machine.go
@@ -373,8 +373,6 @@ func (s *StateNode) executeOnEntryActions(c Context, e Event) error {
 			actionsToCall = append(actionsToCall, onEntryActions...)
 		}
 
-		// Be sure to execute the OnEntry actions of the root state node, which has a parentStateNode of nil.
-
 		stateNodeToEntry = stateNodeToEntry.parentStateNode
 	}
 
@@ -401,8 +399,8 @@ func (s *StateNode) executeOnEntryActions(c Context, e Event) error {
 func (s *StateNode) executeOnExitActions(c Context, e Event) error {
 	stateNodeToExit := s
 
-	for {
-		if onExitActions := s.OnExit; onExitActions != nil {
+	for stateNodeToExit != nil {
+		if onExitActions := stateNodeToExit.OnExit; onExitActions != nil {
 			for index, action := range onExitActions {
 				if err := action(c, e); err != nil {
 					return &ErrAction{
@@ -412,11 +410,6 @@ func (s *StateNode) executeOnExitActions(c Context, e Event) error {
 					}
 				}
 			}
-		}
-
-		// Be sure to execute the OnEntry actions of the root state node, which has a parentStateNode of nil.
-		if stateNodeToExit == nil {
-			break
 		}
 
 		stateNodeToExit = stateNodeToExit.parentStateNode
@@ -602,7 +595,7 @@ func (machine *Machine) Send(event Event) (*StateNode, error) {
 				continue
 			}
 
-			var stateNodeToEnter *StateNode = machine.current
+			stateNodeToEnter := machine.current
 			if target := transition.Target; target != NoneState {
 				// Get parent node to be able to target sibbling state nodes.
 				parentStateNode := stateNode.parentStateNode

--- a/machine_test.go
+++ b/machine_test.go
@@ -492,30 +492,30 @@ func TestFailingEntryActionAbortsTransition(t *testing.T) {
 	failingOnEntryTransition.AssertExpectations(t)
 }
 
-// func TestPreemptivelyValidatesTransitions(t *testing.T) {
-// 	assert := assert.New(t)
+func TestPreemptivelyValidatesTransitions(t *testing.T) {
+	assert := assert.New(t)
 
-// 	invalidStateMachine, err := brainy.NewMachine(brainy.StateNode{
-// 		Initial: OffState,
+	invalidStateMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: OffState,
 
-// 		States: brainy.StateNodes{
-// 			OnState: brainy.StateNode{
-// 				On: brainy.Events{
-// 					OffEvent: IncrementState,
-// 				},
-// 			},
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
+				On: brainy.Events{
+					OffEvent: IncrementState,
+				},
+			},
 
-// 			OffState: brainy.StateNode{
-// 				On: brainy.Events{
-// 					OnEvent: OnState,
-// 				},
-// 			},
-// 		},
-// 	})
-// 	assert.Nil(invalidStateMachine)
-// 	assert.Error(err)
-// 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
-// }
+			OffState: &brainy.StateNode{
+				On: brainy.Events{
+					OnEvent: OnState,
+				},
+			},
+		},
+	})
+	assert.Nil(invalidStateMachine)
+	assert.Error(err)
+	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
+}
 
 func TestCompoundStates(t *testing.T) {
 	assert := assert.New(t)
@@ -593,6 +593,4 @@ func TestCompoundStates(t *testing.T) {
 	nextState, err := compoundStateMachine.Send(ExitCompoundState)
 	assert.NoError(err)
 	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(AtomicState))
-
-	// assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -22,10 +22,10 @@ const (
 func TestOnOffMachine(t *testing.T) {
 	assert := assert.New(t)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: OffState,
@@ -38,8 +38,8 @@ func TestOnOffMachine(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
 
@@ -86,10 +86,10 @@ type IncrementStateMachineContext struct {
 func TestCondIsTrueByDefault(t *testing.T) {
 	assert := assert.New(t)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: OffState,
@@ -102,8 +102,8 @@ func TestCondIsTrueByDefault(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
 
@@ -115,10 +115,10 @@ func TestCondIsTrueByDefault(t *testing.T) {
 func TestCondTakesAGuardFunction(t *testing.T) {
 	assert := assert.New(t)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OnState,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: brainy.Transition{
@@ -141,12 +141,12 @@ func TestCondTakesAGuardFunction(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OnState, onOffMachine.Current())
 
-	_, err := onOffMachine.Send(OffEvent)
+	_, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
@@ -169,12 +169,12 @@ func TestAllActionsOfATransitionAreCalled(t *testing.T) {
 	thirdTransitionAction := new(mocks.Action)
 	thirdTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OnState,
 
 		Context: onOffMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: brainy.Transition{
@@ -196,12 +196,12 @@ func TestAllActionsOfATransitionAreCalled(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OnState, onOffMachine.Current())
 
-	_, err := onOffMachine.Send(OffEvent)
+	_, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
@@ -221,12 +221,12 @@ func TestAFailingActionShortCircuitsTransition(t *testing.T) {
 	secondTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(unexpectedError)
 	thirdTransitionAction := new(mocks.Action)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OnState,
 
 		Context: onOffMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: brainy.Transition{
@@ -248,8 +248,8 @@ func TestAFailingActionShortCircuitsTransition(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OnState, onOffMachine.Current())
 
@@ -271,12 +271,12 @@ func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
 		ToIncrement: 0,
 	}
 
-	incrementVariableInContextMachine := brainy.Machine{
+	incrementVariableInContextMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: IncrementState,
 
 		Context: &stateMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			IncrementState: brainy.StateNode{
 				On: brainy.Events{
 					IncrementEventType: brainy.Transitions{
@@ -304,8 +304,8 @@ func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
 				},
 			},
 		},
-	}
-	incrementVariableInContextMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(0, stateMachineContext.ToIncrement)
 
@@ -336,12 +336,12 @@ func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
 	secondGuardCondition := new(mocks.Cond)
 	thirdGuardCondition := new(mocks.Cond)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
 		Context: onOffMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{},
 
 			OffState: brainy.StateNode{
@@ -363,12 +363,12 @@ func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
 
-	_, err := onOffMachine.Send(OnEvent)
+	_, err = onOffMachine.Send(OnEvent)
 	assert.NoError(err)
 
 	assert.Equal(OnState, onOffMachine.Current())
@@ -399,12 +399,12 @@ func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
 		actionsCallsOrder = append(actionsCallsOrder, "onEnter")
 	})
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
 		Context: onOffMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				OnEntry: brainy.Actions{
 					onEnterOnStateAction.Execute,
@@ -426,12 +426,12 @@ func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
 
-	_, err := onOffMachine.Send(OnEvent)
+	_, err = onOffMachine.Send(OnEvent)
 	assert.NoError(err)
 
 	assert.Equal(OnState, onOffMachine.Current())
@@ -454,12 +454,12 @@ func TestFailingEntryActionAbortsTransition(t *testing.T) {
 	failingOnEntryTransition := new(mocks.Action)
 	failingOnEntryTransition.On("Execute", onOffMachineContext, OnEvent).Return(failingOnExitTransitionError)
 
-	onOffMachine := brainy.Machine{
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
 		Context: onOffMachineContext,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				OnEntry: brainy.Actions{
 					failingOnEntryTransition.Execute,
@@ -473,8 +473,8 @@ func TestFailingEntryActionAbortsTransition(t *testing.T) {
 				},
 			},
 		},
-	}
-	onOffMachine.Init()
+	})
+	assert.NoError(err)
 
 	assert.Equal(OffState, onOffMachine.Current())
 
@@ -490,10 +490,10 @@ func TestFailingEntryActionAbortsTransition(t *testing.T) {
 func TestPreemptivelyValidatesTransitions(t *testing.T) {
 	assert := assert.New(t)
 
-	invalidStateMachine := brainy.Machine{
+	invalidStateMachine, err := brainy.NewMachine(brainy.StateNode{
 		Initial: OffState,
 
-		StateNodes: brainy.StateNodes{
+		States: brainy.StateNodes{
 			OnState: brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: IncrementState,
@@ -506,18 +506,11 @@ func TestPreemptivelyValidatesTransitions(t *testing.T) {
 				},
 			},
 		},
-	}
-	err := invalidStateMachine.Init()
+	})
+	assert.Nil(invalidStateMachine)
 	assert.Error(err)
 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
-
-	nextState, err := invalidStateMachine.Send(OnEvent)
-	assert.Equal(brainy.NoneState, nextState)
-	assert.Error(err)
-	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
-
-	currentState := invalidStateMachine.Current()
-	assert.Equal(brainy.NoneState, currentState)
+}
 
 	currentState = invalidStateMachine.UnsafeCurrent()
 	assert.Equal(brainy.NoneState, currentState)

--- a/machine_test.go
+++ b/machine_test.go
@@ -1,14 +1,13 @@
 package brainy_test
 
 import (
-	"errors"
+	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/Devessier/brainy"
 	"github.com/Devessier/brainy/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -26,13 +25,13 @@ func TestOnOffMachine(t *testing.T) {
 		Initial: OffState,
 
 		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
+			OnState: &brainy.StateNode{
 				On: brainy.Events{
 					OffEvent: OffState,
 				},
 			},
 
-			OffState: brainy.StateNode{
+			OffState: &brainy.StateNode{
 				On: brainy.Events{
 					OnEvent: OnState,
 				},
@@ -41,480 +40,554 @@ func TestOnOffMachine(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Equal(OffState, onOffMachine.Current())
+	assert.Contains(onOffMachine.Current().Value(), OffState.String())
 
 	nextState, err := onOffMachine.Send(OnEvent)
 	assert.NoError(err)
-	assert.Equal(OnState, nextState)
-	assert.Equal(OnState, onOffMachine.Current())
+	assert.Contains(nextState.Value(), OnState.String())
+	assert.Contains(onOffMachine.Current().Value(), OnState.String())
 
 	nextState, err = onOffMachine.Send(OnEvent)
+	assert.Contains(nextState.Value(), OnState.String())
 	assert.Error(err)
 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 
 	nextState, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
-	assert.Equal(OffState, nextState)
-	assert.Equal(OffState, onOffMachine.Current())
+	assert.Contains(nextState.Value(), OffState.String())
+	assert.Contains(onOffMachine.Current().Value(), OffState.String())
 }
 
-const (
-	IncrementState brainy.StateType = "increment"
+// const (
+// 	IncrementState brainy.StateType = "increment"
 
-	IncrementEventType brainy.EventType = "INCREMENT"
-	UnknownEventType   brainy.EventType = "UNKNOWN"
-)
+// 	IncrementEventType brainy.EventType = "INCREMENT"
+// 	UnknownEventType   brainy.EventType = "UNKNOWN"
+// )
 
-type IncrementEvent struct {
-	brainy.EventWithType
-	IncrementBy int
-}
+// type IncrementEvent struct {
+// 	brainy.EventWithType
+// 	IncrementBy int
+// }
 
-func NewIncrementEvent(incrementBy int) IncrementEvent {
-	return IncrementEvent{
-		EventWithType: brainy.EventWithType{
-			Event: IncrementEventType,
-		},
-		IncrementBy: incrementBy,
-	}
-}
+// func NewIncrementEvent(incrementBy int) IncrementEvent {
+// 	return IncrementEvent{
+// 		EventWithType: brainy.EventWithType{
+// 			Event: IncrementEventType,
+// 		},
+// 		IncrementBy: incrementBy,
+// 	}
+// }
 
-type IncrementStateMachineContext struct {
-	ToIncrement int
-}
+// type IncrementStateMachineContext struct {
+// 	ToIncrement int
+// }
 
-func TestCondIsTrueByDefault(t *testing.T) {
+// func TestCondIsTrueByDefault(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OffState,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OffEvent: OffState,
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: OnState,
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+
+// 	onOffMachine.Send(OnEvent)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+// }
+
+// func TestCondTakesAGuardFunction(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OnState,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OffEvent: brainy.Transition{
+// 						Cond: func(c brainy.Context, e brainy.Event) bool {
+// 							return true
+// 						},
+// 						Target: OffState,
+// 					},
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: brainy.Transition{
+// 						Cond: func(c brainy.Context, e brainy.Event) bool {
+// 							return false
+// 						},
+// 						Target: OnState,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+
+// 	_, err = onOffMachine.Send(OffEvent)
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+
+// 	_, err = onOffMachine.Send(OnEvent)
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+// }
+
+// func TestAllActionsOfATransitionAreCalled(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachineContext := &struct{}{}
+
+// 	firstTransitionAction := new(mocks.Action)
+// 	firstTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
+// 	secondTransitionAction := new(mocks.Action)
+// 	secondTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
+// 	thirdTransitionAction := new(mocks.Action)
+// 	thirdTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OnState,
+
+// 		Context: onOffMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OffEvent: brainy.Transition{
+// 						Target: OffState,
+// 						Actions: brainy.Actions{
+// 							firstTransitionAction.Execute,
+// 							secondTransitionAction.Execute,
+// 							thirdTransitionAction.Execute,
+// 						},
+// 					},
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: brainy.Transition{
+// 						Target: OnState,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+
+// 	_, err = onOffMachine.Send(OffEvent)
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+// 	firstTransitionAction.AssertExpectations(t)
+// 	secondTransitionAction.AssertExpectations(t)
+// 	thirdTransitionAction.AssertExpectations(t)
+// }
+// func TestAFailingActionShortCircuitsTransition(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachineContext := &struct{}{}
+// 	unexpectedError := errors.New("this action must fail")
+
+// 	firstTransitionAction := new(mocks.Action)
+// 	firstTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
+// 	secondTransitionAction := new(mocks.Action)
+// 	secondTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(unexpectedError)
+// 	thirdTransitionAction := new(mocks.Action)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OnState,
+
+// 		Context: onOffMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OffEvent: brainy.Transition{
+// 						Target: OffState,
+// 						Actions: brainy.Actions{
+// 							firstTransitionAction.Execute,
+// 							secondTransitionAction.Execute,
+// 							thirdTransitionAction.Execute,
+// 						},
+// 					},
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: brainy.Transition{
+// 						Target: OnState,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+
+// 	nextState, err := onOffMachine.Send(OffEvent)
+// 	assert.Equal(OnState, nextState)
+// 	assert.Error(err)
+// 	assert.ErrorIs(err, unexpectedError)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+// 	firstTransitionAction.AssertExpectations(t)
+// 	secondTransitionAction.AssertExpectations(t)
+// 	thirdTransitionAction.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
+// }
+
+// func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	stateMachineContext := IncrementStateMachineContext{
+// 		ToIncrement: 0,
+// 	}
+
+// 	incrementVariableInContextMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: IncrementState,
+
+// 		Context: &stateMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			IncrementState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					IncrementEventType: brainy.Transitions{
+// 						brainy.Transition{
+// 							Cond: func(c brainy.Context, e brainy.Event) bool {
+// 								return true
+// 							},
+// 							Target: brainy.NoneState,
+// 							Actions: brainy.Actions{
+// 								func(c brainy.Context, e brainy.Event) error {
+// 									ctx := c.(*IncrementStateMachineContext)
+
+// 									switch ev := e.(type) {
+// 									case IncrementEvent:
+// 										ctx.ToIncrement += ev.IncrementBy
+// 									default:
+// 										ctx.ToIncrement += 1
+// 									}
+
+// 									return nil
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(0, stateMachineContext.ToIncrement)
+
+// 	nextState, err := incrementVariableInContextMachine.Send(NewIncrementEvent(2))
+// 	assert.Equal(IncrementState, nextState)
+// 	assert.NoError(err)
+// 	assert.Equal(2, stateMachineContext.ToIncrement)
+
+// 	nextState, err = incrementVariableInContextMachine.Send(IncrementEventType)
+// 	assert.Equal(IncrementState, nextState)
+// 	assert.NoError(err)
+// 	assert.Equal(3, stateMachineContext.ToIncrement)
+
+// 	nextState, err = incrementVariableInContextMachine.Send(UnknownEventType)
+// 	assert.Equal(IncrementState, nextState)
+// 	assert.Error(err)
+// 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
+// 	assert.Equal(3, stateMachineContext.ToIncrement)
+// }
+
+// func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachineContext := &struct{}{}
+
+// 	firstGuardCondition := new(mocks.Cond)
+// 	firstGuardCondition.On("Execute", onOffMachineContext, OnEvent).Return(true)
+// 	secondGuardCondition := new(mocks.Cond)
+// 	thirdGuardCondition := new(mocks.Cond)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OffState,
+
+// 		Context: onOffMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: brainy.Transitions{
+// 						{
+// 							Cond:   firstGuardCondition.Execute,
+// 							Target: OnState,
+// 						},
+// 						{
+// 							Cond:   secondGuardCondition.Execute,
+// 							Target: OnState,
+// 						},
+// 						{
+// 							Cond:   thirdGuardCondition.Execute,
+// 							Target: OnState,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+
+// 	_, err = onOffMachine.Send(OnEvent)
+// 	assert.NoError(err)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+// 	firstGuardCondition.AssertExpectations(t)
+// 	secondGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
+// 	thirdGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
+// }
+
+// func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachineContext := &struct{}{}
+
+// 	actionsCallsOrder := []string{}
+
+// 	onExitOffStateAction := new(mocks.Action)
+// 	onExitOffStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+// 		actionsCallsOrder = append(actionsCallsOrder, "onExit")
+// 	})
+
+// 	transitionAction := new(mocks.Action)
+// 	transitionAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+// 		actionsCallsOrder = append(actionsCallsOrder, "action")
+// 	})
+
+// 	onEnterOnStateAction := new(mocks.Action)
+// 	onEnterOnStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+// 		actionsCallsOrder = append(actionsCallsOrder, "onEnter")
+// 	})
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OffState,
+
+// 		Context: onOffMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				OnEntry: brainy.Actions{
+// 					onEnterOnStateAction.Execute,
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				OnExit: brainy.Actions{
+// 					onExitOffStateAction.Execute,
+// 				},
+
+// 				On: brainy.Events{
+// 					OnEvent: brainy.Transition{
+// 						Target: OnState,
+// 						Actions: brainy.Actions{
+// 							transitionAction.Execute,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+
+// 	_, err = onOffMachine.Send(OnEvent)
+// 	assert.NoError(err)
+
+// 	assert.Equal(OnState, onOffMachine.Current())
+// 	onExitOffStateAction.AssertExpectations(t)
+// 	transitionAction.AssertExpectations(t)
+// 	onEnterOnStateAction.AssertExpectations(t)
+// 	assert.Equal([]string{
+// 		"onExit",
+// 		"action",
+// 		"onEnter",
+// 	}, actionsCallsOrder)
+// }
+
+// func TestFailingEntryActionAbortsTransition(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	onOffMachineContext := &struct{}{}
+// 	failingOnExitTransitionError := errors.New("this action must fail")
+
+// 	failingOnEntryTransition := new(mocks.Action)
+// 	failingOnEntryTransition.On("Execute", onOffMachineContext, OnEvent).Return(failingOnExitTransitionError)
+
+// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OffState,
+
+// 		Context: onOffMachineContext,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				OnEntry: brainy.Actions{
+// 					failingOnEntryTransition.Execute,
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+
+// 				On: brainy.Events{
+// 					OnEvent: OnState,
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.NoError(err)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+
+// 	nextState, err := onOffMachine.Send(OnEvent)
+// 	assert.Equal(OffState, nextState)
+// 	assert.Error(err)
+// 	assert.ErrorIs(err, failingOnExitTransitionError)
+
+// 	assert.Equal(OffState, onOffMachine.Current())
+// 	failingOnEntryTransition.AssertExpectations(t)
+// }
+
+// func TestPreemptivelyValidatesTransitions(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	invalidStateMachine, err := brainy.NewMachine(brainy.StateNode{
+// 		Initial: OffState,
+
+// 		States: brainy.StateNodes{
+// 			OnState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OffEvent: IncrementState,
+// 				},
+// 			},
+
+// 			OffState: brainy.StateNode{
+// 				On: brainy.Events{
+// 					OnEvent: OnState,
+// 				},
+// 			},
+// 		},
+// 	})
+// 	assert.Nil(invalidStateMachine)
+// 	assert.Error(err)
+// 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
+// }
+
+func TestCompoundStates(t *testing.T) {
 	assert := assert.New(t)
 
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OffState,
+	const (
+		CompoundState brainy.StateType = "compound"
+		NestedAState  brainy.StateType = "nested-a"
+		NestedBState  brainy.StateType = "nested-b"
+		AtomicState   brainy.StateType = "atomic"
+
+		GoToNestedBState  brainy.EventType = "GO_TO_NESTED_B_STATE"
+		ExitCompoundState brainy.EventType = "EXIT_COMPOUND_STATE"
+	)
+
+	compoundStateOnEntryAction := new(mocks.Action)
+	compoundStateOnEntryAction.On("Execute", mock.Anything, mock.Anything).Return(nil)
+
+	compoundStateMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: CompoundState,
 
 		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				On: brainy.Events{
-					OffEvent: OffState,
-				},
-			},
+			CompoundState: &brainy.StateNode{
+				Initial: NestedAState,
 
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: OnState,
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-
-	onOffMachine.Send(OnEvent)
-
-	assert.Equal(OnState, onOffMachine.Current())
-}
-
-func TestCondTakesAGuardFunction(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OnState,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				On: brainy.Events{
-					OffEvent: brainy.Transition{
-						Cond: func(c brainy.Context, e brainy.Event) bool {
-							return true
-						},
-						Target: OffState,
-					},
-				},
-			},
-
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: brainy.Transition{
-						Cond: func(c brainy.Context, e brainy.Event) bool {
-							return false
-						},
-						Target: OnState,
-					},
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OnState, onOffMachine.Current())
-
-	_, err = onOffMachine.Send(OffEvent)
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-
-	_, err = onOffMachine.Send(OnEvent)
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-}
-
-func TestAllActionsOfATransitionAreCalled(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachineContext := &struct{}{}
-
-	firstTransitionAction := new(mocks.Action)
-	firstTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
-	secondTransitionAction := new(mocks.Action)
-	secondTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
-	thirdTransitionAction := new(mocks.Action)
-	thirdTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OnState,
-
-		Context: onOffMachineContext,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				On: brainy.Events{
-					OffEvent: brainy.Transition{
-						Target: OffState,
-						Actions: brainy.Actions{
-							firstTransitionAction.Execute,
-							secondTransitionAction.Execute,
-							thirdTransitionAction.Execute,
-						},
-					},
-				},
-			},
-
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: brainy.Transition{
-						Target: OnState,
-					},
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OnState, onOffMachine.Current())
-
-	_, err = onOffMachine.Send(OffEvent)
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-	firstTransitionAction.AssertExpectations(t)
-	secondTransitionAction.AssertExpectations(t)
-	thirdTransitionAction.AssertExpectations(t)
-}
-func TestAFailingActionShortCircuitsTransition(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachineContext := &struct{}{}
-	unexpectedError := errors.New("this action must fail")
-
-	firstTransitionAction := new(mocks.Action)
-	firstTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(nil)
-	secondTransitionAction := new(mocks.Action)
-	secondTransitionAction.On("Execute", onOffMachineContext, OffEvent).Return(unexpectedError)
-	thirdTransitionAction := new(mocks.Action)
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OnState,
-
-		Context: onOffMachineContext,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				On: brainy.Events{
-					OffEvent: brainy.Transition{
-						Target: OffState,
-						Actions: brainy.Actions{
-							firstTransitionAction.Execute,
-							secondTransitionAction.Execute,
-							thirdTransitionAction.Execute,
-						},
-					},
-				},
-			},
-
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: brainy.Transition{
-						Target: OnState,
-					},
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OnState, onOffMachine.Current())
-
-	nextState, err := onOffMachine.Send(OffEvent)
-	assert.Equal(OnState, nextState)
-	assert.Error(err)
-	assert.ErrorIs(err, unexpectedError)
-
-	assert.Equal(OnState, onOffMachine.Current())
-	firstTransitionAction.AssertExpectations(t)
-	secondTransitionAction.AssertExpectations(t)
-	thirdTransitionAction.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
-}
-
-func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
-	assert := assert.New(t)
-
-	stateMachineContext := IncrementStateMachineContext{
-		ToIncrement: 0,
-	}
-
-	incrementVariableInContextMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: IncrementState,
-
-		Context: &stateMachineContext,
-
-		States: brainy.StateNodes{
-			IncrementState: brainy.StateNode{
-				On: brainy.Events{
-					IncrementEventType: brainy.Transitions{
-						brainy.Transition{
-							Cond: func(c brainy.Context, e brainy.Event) bool {
-								return true
-							},
-							Target: brainy.NoneState,
-							Actions: brainy.Actions{
-								func(c brainy.Context, e brainy.Event) error {
-									ctx := c.(*IncrementStateMachineContext)
-
-									switch ev := e.(type) {
-									case IncrementEvent:
-										ctx.ToIncrement += ev.IncrementBy
-									default:
-										ctx.ToIncrement += 1
-									}
-
-									return nil
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(0, stateMachineContext.ToIncrement)
-
-	nextState, err := incrementVariableInContextMachine.Send(NewIncrementEvent(2))
-	assert.Equal(IncrementState, nextState)
-	assert.NoError(err)
-	assert.Equal(2, stateMachineContext.ToIncrement)
-
-	nextState, err = incrementVariableInContextMachine.Send(IncrementEventType)
-	assert.Equal(IncrementState, nextState)
-	assert.NoError(err)
-	assert.Equal(3, stateMachineContext.ToIncrement)
-
-	nextState, err = incrementVariableInContextMachine.Send(UnknownEventType)
-	assert.Equal(IncrementState, nextState)
-	assert.Error(err)
-	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
-	assert.Equal(3, stateMachineContext.ToIncrement)
-}
-
-func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachineContext := &struct{}{}
-
-	firstGuardCondition := new(mocks.Cond)
-	firstGuardCondition.On("Execute", onOffMachineContext, OnEvent).Return(true)
-	secondGuardCondition := new(mocks.Cond)
-	thirdGuardCondition := new(mocks.Cond)
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OffState,
-
-		Context: onOffMachineContext,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{},
-
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: brainy.Transitions{
-						{
-							Cond:   firstGuardCondition.Execute,
-							Target: OnState,
-						},
-						{
-							Cond:   secondGuardCondition.Execute,
-							Target: OnState,
-						},
-						{
-							Cond:   thirdGuardCondition.Execute,
-							Target: OnState,
-						},
-					},
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-
-	_, err = onOffMachine.Send(OnEvent)
-	assert.NoError(err)
-
-	assert.Equal(OnState, onOffMachine.Current())
-	firstGuardCondition.AssertExpectations(t)
-	secondGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
-	thirdGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
-}
-
-func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachineContext := &struct{}{}
-
-	actionsCallsOrder := []string{}
-
-	onExitOffStateAction := new(mocks.Action)
-	onExitOffStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-		actionsCallsOrder = append(actionsCallsOrder, "onExit")
-	})
-
-	transitionAction := new(mocks.Action)
-	transitionAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-		actionsCallsOrder = append(actionsCallsOrder, "action")
-	})
-
-	onEnterOnStateAction := new(mocks.Action)
-	onEnterOnStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-		actionsCallsOrder = append(actionsCallsOrder, "onEnter")
-	})
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OffState,
-
-		Context: onOffMachineContext,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
 				OnEntry: brainy.Actions{
-					onEnterOnStateAction.Execute,
+					compoundStateOnEntryAction.Execute,
 				},
-			},
 
-			OffState: brainy.StateNode{
-				OnExit: brainy.Actions{
-					onExitOffStateAction.Execute,
+				States: brainy.StateNodes{
+					NestedAState: &brainy.StateNode{
+						OnEntry: brainy.Actions{
+							func(c brainy.Context, e brainy.Event) error {
+								fmt.Println("nested a state entered")
+
+								return nil
+							},
+						},
+
+						On: brainy.Events{
+							GoToNestedBState: NestedBState,
+						},
+					},
+
+					NestedBState: &brainy.StateNode{
+						OnEntry: brainy.Actions{
+							func(c brainy.Context, e brainy.Event) error {
+								fmt.Println("nested a state entered")
+
+								return nil
+							},
+						},
+					},
 				},
 
 				On: brainy.Events{
-					OnEvent: brainy.Transition{
-						Target: OnState,
-						Actions: brainy.Actions{
-							transitionAction.Execute,
-						},
+					ExitCompoundState: AtomicState,
+				},
+			},
+
+			AtomicState: &brainy.StateNode{
+				On: brainy.Events{
+					GoToNestedBState: brainy.CompoundTarget{
+						CompoundState: NestedBState,
 					},
 				},
 			},
 		},
 	})
+	assert.NotNil(compoundStateMachine)
 	assert.NoError(err)
 
-	assert.Equal(OffState, onOffMachine.Current())
+	compoundStateOnEntryAction.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
+	assert.Contains(compoundStateMachine.Current().Value(), brainy.JoinStatesIDs(CompoundState, NestedAState))
 
-	_, err = onOffMachine.Send(OnEvent)
+	nextState, err := compoundStateMachine.Send(ExitCompoundState)
 	assert.NoError(err)
+	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(AtomicState))
 
-	assert.Equal(OnState, onOffMachine.Current())
-	onExitOffStateAction.AssertExpectations(t)
-	transitionAction.AssertExpectations(t)
-	onEnterOnStateAction.AssertExpectations(t)
-	assert.Equal([]string{
-		"onExit",
-		"action",
-		"onEnter",
-	}, actionsCallsOrder)
-}
-
-func TestFailingEntryActionAbortsTransition(t *testing.T) {
-	assert := assert.New(t)
-
-	onOffMachineContext := &struct{}{}
-	failingOnExitTransitionError := errors.New("this action must fail")
-
-	failingOnEntryTransition := new(mocks.Action)
-	failingOnEntryTransition.On("Execute", onOffMachineContext, OnEvent).Return(failingOnExitTransitionError)
-
-	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OffState,
-
-		Context: onOffMachineContext,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				OnEntry: brainy.Actions{
-					failingOnEntryTransition.Execute,
-				},
-			},
-
-			OffState: brainy.StateNode{
-
-				On: brainy.Events{
-					OnEvent: OnState,
-				},
-			},
-		},
-	})
-	assert.NoError(err)
-
-	assert.Equal(OffState, onOffMachine.Current())
-
-	nextState, err := onOffMachine.Send(OnEvent)
-	assert.Equal(OffState, nextState)
-	assert.Error(err)
-	assert.ErrorIs(err, failingOnExitTransitionError)
-
-	assert.Equal(OffState, onOffMachine.Current())
-	failingOnEntryTransition.AssertExpectations(t)
-}
-
-func TestPreemptivelyValidatesTransitions(t *testing.T) {
-	assert := assert.New(t)
-
-	invalidStateMachine, err := brainy.NewMachine(brainy.StateNode{
-		Initial: OffState,
-
-		States: brainy.StateNodes{
-			OnState: brainy.StateNode{
-				On: brainy.Events{
-					OffEvent: IncrementState,
-				},
-			},
-
-			OffState: brainy.StateNode{
-				On: brainy.Events{
-					OnEvent: OnState,
-				},
-			},
-		},
-	})
-	assert.Nil(invalidStateMachine)
-	assert.Error(err)
-	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
-}
-
-	currentState = invalidStateMachine.UnsafeCurrent()
-	assert.Equal(brainy.NoneState, currentState)
-
-	previousState := invalidStateMachine.Current()
-	assert.Equal(brainy.NoneState, previousState)
+	// assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -332,124 +332,124 @@ func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
 	assert.Equal(3, stateMachineContext.ToIncrement)
 }
 
-// func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
-// 	assert := assert.New(t)
+func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
+	assert := assert.New(t)
 
-// 	onOffMachineContext := &struct{}{}
+	onOffMachineContext := &struct{}{}
 
-// 	firstGuardCondition := new(mocks.Cond)
-// 	firstGuardCondition.On("Execute", onOffMachineContext, OnEvent).Return(true)
-// 	secondGuardCondition := new(mocks.Cond)
-// 	thirdGuardCondition := new(mocks.Cond)
+	firstGuardCondition := new(mocks.Cond)
+	firstGuardCondition.On("Execute", onOffMachineContext, OnEvent).Return(true)
+	secondGuardCondition := new(mocks.Cond)
+	thirdGuardCondition := new(mocks.Cond)
 
-// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-// 		Initial: OffState,
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: OffState,
 
-// 		Context: onOffMachineContext,
+		Context: onOffMachineContext,
 
-// 		States: brainy.StateNodes{
-// 			OnState: brainy.StateNode{},
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{},
 
-// 			OffState: brainy.StateNode{
-// 				On: brainy.Events{
-// 					OnEvent: brainy.Transitions{
-// 						{
-// 							Cond:   firstGuardCondition.Execute,
-// 							Target: OnState,
-// 						},
-// 						{
-// 							Cond:   secondGuardCondition.Execute,
-// 							Target: OnState,
-// 						},
-// 						{
-// 							Cond:   thirdGuardCondition.Execute,
-// 							Target: OnState,
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 	})
-// 	assert.NoError(err)
+			OffState: &brainy.StateNode{
+				On: brainy.Events{
+					OnEvent: brainy.Transitions{
+						{
+							Cond:   firstGuardCondition.Execute,
+							Target: OnState,
+						},
+						{
+							Cond:   secondGuardCondition.Execute,
+							Target: OnState,
+						},
+						{
+							Cond:   thirdGuardCondition.Execute,
+							Target: OnState,
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(err)
 
-// 	assert.Equal(OffState, onOffMachine.Current())
+	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
 
-// 	_, err = onOffMachine.Send(OnEvent)
-// 	assert.NoError(err)
+	_, err = onOffMachine.Send(OnEvent)
+	assert.NoError(err)
 
-// 	assert.Equal(OnState, onOffMachine.Current())
-// 	firstGuardCondition.AssertExpectations(t)
-// 	secondGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
-// 	thirdGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
-// }
+	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	firstGuardCondition.AssertExpectations(t)
+	secondGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
+	thirdGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
+}
 
-// func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
-// 	assert := assert.New(t)
+func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
+	assert := assert.New(t)
 
-// 	onOffMachineContext := &struct{}{}
+	onOffMachineContext := &struct{}{}
 
-// 	actionsCallsOrder := []string{}
+	actionsCallsOrder := []string{}
 
-// 	onExitOffStateAction := new(mocks.Action)
-// 	onExitOffStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-// 		actionsCallsOrder = append(actionsCallsOrder, "onExit")
-// 	})
+	onExitOffStateAction := new(mocks.Action)
+	onExitOffStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+		actionsCallsOrder = append(actionsCallsOrder, "onExit")
+	})
 
-// 	transitionAction := new(mocks.Action)
-// 	transitionAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-// 		actionsCallsOrder = append(actionsCallsOrder, "action")
-// 	})
+	transitionAction := new(mocks.Action)
+	transitionAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+		actionsCallsOrder = append(actionsCallsOrder, "action")
+	})
 
-// 	onEnterOnStateAction := new(mocks.Action)
-// 	onEnterOnStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
-// 		actionsCallsOrder = append(actionsCallsOrder, "onEnter")
-// 	})
+	onEnterOnStateAction := new(mocks.Action)
+	onEnterOnStateAction.On("Execute", onOffMachineContext, OnEvent).Return(nil).Run(func(args mock.Arguments) {
+		actionsCallsOrder = append(actionsCallsOrder, "onEnter")
+	})
 
-// 	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
-// 		Initial: OffState,
+	onOffMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: OffState,
 
-// 		Context: onOffMachineContext,
+		Context: onOffMachineContext,
 
-// 		States: brainy.StateNodes{
-// 			OnState: brainy.StateNode{
-// 				OnEntry: brainy.Actions{
-// 					onEnterOnStateAction.Execute,
-// 				},
-// 			},
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
+				OnEntry: brainy.Actions{
+					onEnterOnStateAction.Execute,
+				},
+			},
 
-// 			OffState: brainy.StateNode{
-// 				OnExit: brainy.Actions{
-// 					onExitOffStateAction.Execute,
-// 				},
+			OffState: &brainy.StateNode{
+				OnExit: brainy.Actions{
+					onExitOffStateAction.Execute,
+				},
 
-// 				On: brainy.Events{
-// 					OnEvent: brainy.Transition{
-// 						Target: OnState,
-// 						Actions: brainy.Actions{
-// 							transitionAction.Execute,
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 	})
-// 	assert.NoError(err)
+				On: brainy.Events{
+					OnEvent: brainy.Transition{
+						Target: OnState,
+						Actions: brainy.Actions{
+							transitionAction.Execute,
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(err)
 
-// 	assert.Equal(OffState, onOffMachine.Current())
+	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
 
-// 	_, err = onOffMachine.Send(OnEvent)
-// 	assert.NoError(err)
+	_, err = onOffMachine.Send(OnEvent)
+	assert.NoError(err)
 
-// 	assert.Equal(OnState, onOffMachine.Current())
-// 	onExitOffStateAction.AssertExpectations(t)
-// 	transitionAction.AssertExpectations(t)
-// 	onEnterOnStateAction.AssertExpectations(t)
-// 	assert.Equal([]string{
-// 		"onExit",
-// 		"action",
-// 		"onEnter",
-// 	}, actionsCallsOrder)
-// }
+	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	onExitOffStateAction.AssertExpectations(t)
+	transitionAction.AssertExpectations(t)
+	onEnterOnStateAction.AssertExpectations(t)
+	assert.Equal([]string{
+		"onExit",
+		"action",
+		"onEnter",
+	}, actionsCallsOrder)
+}
 
 // func TestFailingEntryActionAbortsTransition(t *testing.T) {
 // 	assert := assert.New(t)

--- a/machine_test.go
+++ b/machine_test.go
@@ -40,22 +40,22 @@ func TestOnOffMachine(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), OffState.String())
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	nextState, err := onOffMachine.Send(OnEvent)
 	assert.NoError(err)
-	assert.Contains(nextState.Value(), OnState.String())
-	assert.Contains(onOffMachine.Current().Value(), OnState.String())
+	assert.True(nextState.Matches(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 
 	nextState, err = onOffMachine.Send(OnEvent)
-	assert.Contains(nextState.Value(), OnState.String())
+	assert.True(nextState.Matches(OnState))
 	assert.Error(err)
 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 
 	nextState, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
-	assert.Contains(nextState.Value(), OffState.String())
-	assert.Contains(onOffMachine.Current().Value(), OffState.String())
+	assert.True(nextState.Matches(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 }
 
 const (
@@ -105,11 +105,11 @@ func TestCondIsTrueByDefault(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	onOffMachine.Send(OnEvent)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 }
 
 func TestCondTakesAGuardFunction(t *testing.T) {
@@ -144,18 +144,18 @@ func TestCondTakesAGuardFunction(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 
 	_, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	_, err = onOffMachine.Send(OnEvent)
 	assert.Error(err)
 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 }
 
 func TestAllActionsOfATransitionAreCalled(t *testing.T) {
@@ -200,12 +200,12 @@ func TestAllActionsOfATransitionAreCalled(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 
 	_, err = onOffMachine.Send(OffEvent)
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 	firstTransitionAction.AssertExpectations(t)
 	secondTransitionAction.AssertExpectations(t)
 	thirdTransitionAction.AssertExpectations(t)
@@ -253,14 +253,14 @@ func TestAFailingActionShortCircuitsTransition(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 
 	nextState, err := onOffMachine.Send(OffEvent)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(nextState.Matches(OnState))
 	assert.Error(err)
 	assert.ErrorIs(err, unexpectedError)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 	firstTransitionAction.AssertExpectations(t)
 	secondTransitionAction.AssertExpectations(t)
 	thirdTransitionAction.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
@@ -313,19 +313,19 @@ func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
 
 	nextState, err := incrementVariableInContextMachine.Send(NewIncrementEvent(2))
 	assert.NotNil(nextState)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(IncrementState))
+	assert.True(nextState.Matches(IncrementState))
 	assert.NoError(err)
 	assert.Equal(2, stateMachineContext.ToIncrement)
 
 	nextState, err = incrementVariableInContextMachine.Send(IncrementEventType)
 	assert.NotNil(nextState)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(IncrementState))
+	assert.True(nextState.Matches(IncrementState))
 	assert.NoError(err)
 	assert.Equal(3, stateMachineContext.ToIncrement)
 
 	nextState, err = incrementVariableInContextMachine.Send(UnknownEventType)
 	assert.NotNil(nextState)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(IncrementState))
+	assert.True(nextState.Matches(IncrementState))
 	assert.Error(err)
 	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
 	assert.Equal(3, stateMachineContext.ToIncrement)
@@ -371,12 +371,12 @@ func TestOnlyOneTransitionCanBeTaken(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	_, err = onOffMachine.Send(OnEvent)
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 	firstGuardCondition.AssertExpectations(t)
 	secondGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
 	thirdGuardCondition.AssertNumberOfCalls(t, "Execute", 0)
@@ -434,12 +434,12 @@ func TestOnEntryThenActionsThenOnExitAreCalled(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	_, err = onOffMachine.Send(OnEvent)
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OnState))
+	assert.True(onOffMachine.Current().Matches(OnState))
 	onExitOffStateAction.AssertExpectations(t)
 	transitionAction.AssertExpectations(t)
 	onEnterOnStateAction.AssertExpectations(t)
@@ -480,14 +480,14 @@ func TestFailingEntryActionAbortsTransition(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 
 	nextState, err := onOffMachine.Send(OnEvent)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(nextState.Matches(OffState))
 	assert.Error(err)
 	assert.ErrorIs(err, failingOnExitTransitionError)
 
-	assert.Contains(onOffMachine.Current().Value(), brainy.JoinStatesIDs(OffState))
+	assert.True(onOffMachine.Current().Matches(OffState))
 	failingOnEntryTransition.AssertExpectations(t)
 }
 
@@ -605,15 +605,16 @@ func TestCompoundStates(t *testing.T) {
 
 	compoundStateOnEntryAction.AssertCalled(t, "Execute", nil, brainy.InitialTransitionEventType)
 	nestedAStateStateOnEntryAction.AssertCalled(t, "Execute", nil, brainy.InitialTransitionEventType)
-	assert.Contains(compoundStateMachine.Current().Value(), brainy.JoinStatesIDs(CompoundState, NestedAState))
+	assert.True(compoundStateMachine.Current().Matches(CompoundState, NestedAState))
+	assert.True(compoundStateMachine.Current().Matches(CompoundState, NestedAState))
 
 	nextState, err := compoundStateMachine.Send(GoToNestedBState)
 	assert.NoError(err)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(CompoundState, NestedBState))
+	assert.True(nextState.Matches(CompoundState, NestedBState))
 
 	nextState, err = compoundStateMachine.Send(ExitCompoundState)
 	assert.NoError(err)
-	assert.Contains(nextState.Value(), brainy.JoinStatesIDs(AtomicState))
+	assert.True(nextState.Matches(AtomicState))
 
 	assert.Equal([]string{
 		CompoundStateOnEntry,


### PR DESCRIPTION
We implemented hierarchical states.
State machines should no longer be created using a struct literal. We provide a constructor function that validates the state machine configuration internally: `NewMachine`. Its usage is the new norm to create a state machine.
State nodes in the configuration must be pointers to `StateNode`s. To handle compound states we need each state node to have a reference to its parent, that's why we want to use pointers. This implementation detail will probably be removed from the public API in the future, so that users just describe the state machine and internally we get pointers.
`onentry` and `onexit` actions are called in the correct order for compound states: when entering into a state, all the `onentry` actions are called from the top to the bottom, and when exiting a state, all `onexit` actions are called from deepest to outermost.