### PR TITLE
Allow target to be left blank

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -481,7 +481,7 @@ func (s *StateNode) validate(m *Machine) error {
 
 			for _, transition := range transitions {
 				target := transition.Target
-				if target == NoneState {
+				if target == nil || target == NoneState {
 					continue
 				}
 
@@ -624,7 +624,7 @@ func (machine *Machine) Send(event Event) (*StateNode, error) {
 			}
 
 			stateNodeToEnter := machine.current
-			if target := transition.Target; target != NoneState {
+			if target := transition.Target; target != nil && target != NoneState {
 				// Get parent node to be able to target sibbling state nodes.
 				parentStateNode := stateNode.parentStateNode
 				if parentStateNode == nil {

--- a/machine_test.go
+++ b/machine_test.go
@@ -286,7 +286,6 @@ func TestStateMachineWithTransitionsWithoutTargets(t *testing.T) {
 							Cond: func(c brainy.Context, e brainy.Event) bool {
 								return true
 							},
-							Target: brainy.NoneState,
 							Actions: brainy.Actions{
 								func(c brainy.Context, e brainy.Event) error {
 									ctx := c.(*IncrementStateMachineContext)


### PR DESCRIPTION
When the target is left blank, we must consider it as a transition to the node itself.
Therefore, we must consider an empty target as the same as a transition to `NoneState`.