### PR TITLE
Implement send action

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,26 @@ func main() {
 		States: brainy.StateNodes{
 			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `on` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `on` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OffState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `off` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `off` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},
@@ -55,22 +59,26 @@ func main() {
 
 			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `off` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `off` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OnState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `on` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `on` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},

--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,20 @@
+package brainy
+
+type sendActionEvent struct {
+	SourceEvent Event
+}
+
+func (e sendActionEvent) run(Context, Event) error {
+	return nil
+}
+
+// Send function creates a declarative action, that will send internally the event given
+// as parameter to the state machine itself.
+//
+// Send action does not imperatively send an event to the state machine. It tells brainy to send
+// an event to itself when the action must be executed, that is, when brainy finds it in a list of actions.
+func Send(event Event) Actioner {
+	return sendActionEvent{
+		SourceEvent: event,
+	}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,22 +32,26 @@ func main() {
 		States: brainy.StateNodes{
 			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `on` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `on` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OffState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `off` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `off` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},
@@ -55,22 +59,26 @@ func main() {
 
 			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `off` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `off` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OnState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `on` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `on` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},

--- a/examples/on-off/main.go
+++ b/examples/on-off/main.go
@@ -21,22 +21,26 @@ func main() {
 		States: brainy.StateNodes{
 			OnState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `on` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `on` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OffState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `off` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `off` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},
@@ -44,22 +48,26 @@ func main() {
 
 			OffState: &brainy.StateNode{
 				OnEntry: brainy.Actions{
-					func(c brainy.Context, e brainy.Event) error {
-						fmt.Println("Reached `off` state")
+					brainy.ActionFn(
+						func(c brainy.Context, e brainy.Event) error {
+							fmt.Println("Reached `off` state")
 
-						return nil
-					},
+							return nil
+						},
+					),
 				},
 
 				On: brainy.Events{
 					ToggleEvent: brainy.Transition{
 						Target: OnState,
 						Actions: brainy.Actions{
-							func(c brainy.Context, e brainy.Event) error {
-								fmt.Println("Go to `on` state")
+							brainy.ActionFn(
+								func(c brainy.Context, e brainy.Event) error {
+									fmt.Println("Go to `on` state")
 
-								return nil
-							},
+									return nil
+								},
+							),
 						},
 					},
 				},

--- a/machine_test.go
+++ b/machine_test.go
@@ -153,7 +153,7 @@ func TestCondTakesAGuardFunction(t *testing.T) {
 
 	_, err = onOffMachine.Send(OnEvent)
 	assert.Error(err)
-	assert.ErrorIs(err, brainy.ErrInvalidTransitionNotImplemented)
+	assert.ErrorIs(err, brainy.ErrNoTransitionCouldBeRun)
 
 	assert.True(onOffMachine.Current().Matches(OffState))
 }

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,32 @@
+package brainy
+
+type EventsQueue struct {
+	events []Event
+}
+
+func NewEventsQueue() *EventsQueue {
+	return &EventsQueue{
+		events: make([]Event, 0),
+	}
+}
+
+func (q *EventsQueue) Add(event Event) {
+	q.events = append(q.events, event)
+}
+
+func (q *EventsQueue) Poll() (Event, bool) {
+	eventsCount := len(q.events)
+	if eventsCount == 0 {
+		return nil, false
+	}
+
+	event := q.events[0]
+
+	if eventsCount == 1 {
+		q.events = make([]Event, 0)
+	} else {
+		q.events = q.events[1:]
+	}
+
+	return event, true
+}


### PR DESCRIPTION
We refactored the code to use the same terminology as SCXML specification.

We now use a queue to process external events.
When the `Machine.Send()` method is called with an event, we add this event to the queue of external events. Then we process these external events until the queue is empty.
The benefit is that events can be added to the queue during the `Send` session, while the mutex prevents other accesses.

We implemented the Send action, that will add a message to the external events queue once called. The Send function is a declaration: it tells brainy to send an event when called, it does not imperatively sends an event as would do `Machine.Send()`.

To allow the Send function to exist, we had to change how simple actions are coded. Now an action function needs to be wrapped inside a `ActionFn` function call.