### PR TITLE
Implement option to disable locking

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -678,3 +678,17 @@ func TestCanSendEventsWithSendAction(t *testing.T) {
 	assert.True(nextState.Matches(AtomicState))
 	assert.True(compoundStateMachine.Current().Matches(AtomicState))
 }
+
+func TestCanDisableLocking(t *testing.T) {
+	assert := assert.New(t)
+
+	compoundStateMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: OnState,
+
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{},
+		},
+	}, brainy.WithDisableLocking())
+	assert.NotNil(compoundStateMachine)
+	assert.NoError(err)
+}


### PR DESCRIPTION
We provide an option to disable mutex usage.
This is absolutely **not recommended** to disable mutex usage in most cases. It can be useful in environments where mutex should not be used.