### PR TITLE
Run initial transition actions with correct context

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -618,7 +618,7 @@ func (machine *Machine) init() error {
 	}
 
 	machine.current = machine.StateNode.resolveMostNestedInitialStateNode()
-	if err := machine.current.executeOnEntryActions(machine.current.Context, InitialTransitionEventType); err != nil {
+	if err := machine.current.executeOnEntryActions(machine.StateNode.Context, InitialTransitionEventType); err != nil {
 		return err
 	}
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -692,3 +692,32 @@ func TestCanDisableLocking(t *testing.T) {
 	assert.NotNil(compoundStateMachine)
 	assert.NoError(err)
 }
+
+func TestGivesGlobalContextDuringInitialTransition(t *testing.T) {
+	assert := assert.New(t)
+
+	stateMachineContext := &struct{}{}
+
+	initialStateOnEntryAction := new(mocks.Action)
+	initialStateOnEntryAction.On("Execute", stateMachineContext, brainy.InitialTransitionEventType).Return(nil)
+
+	stateMachine, err := brainy.NewMachine(brainy.StateNode{
+		Context: stateMachineContext,
+
+		Initial: OnState,
+
+		States: brainy.StateNodes{
+			OnState: &brainy.StateNode{
+				OnEntry: brainy.Actions{
+					brainy.ActionFn(
+						initialStateOnEntryAction.Execute,
+					),
+				},
+			},
+		},
+	}, brainy.WithDisableLocking())
+	assert.NotNil(stateMachine)
+	assert.NoError(err)
+
+	initialStateOnEntryAction.AssertExpectations(t)
+}


### PR DESCRIPTION
The context of the state machine is global. Although each state node has a Context property, they are not used currently.
To access the context we need to get it from the root state node.