### PR TITLE
Fix sibling transition in compound state issue

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -634,6 +634,13 @@ func (s *StateNode) validate(m *Machine) error {
 		// Set the parentStateNode of each state node
 		stateNode.parentStateNode = s
 
+		// Recursively validate children states
+		if stateNode.isCompound() {
+			if err := stateNode.validate(m); err != nil {
+				return err
+			}
+		}
+
 		handlers := stateNode.On
 		if handlers == nil {
 			continue

--- a/machine.go
+++ b/machine.go
@@ -454,20 +454,13 @@ func (s *StateNode) resolveMostNestedInitialStateNode() *StateNode {
 	return initialStateNode.resolveMostNestedInitialStateNode()
 }
 
-func (s *StateNode) getTarget(t Targeter) (*StateNode, bool) {
-	targetID := t.String()
-	baseStateNode := s.id
-	if s.parentStateNode != nil {
-		baseStateNode = s.parentStateNode.id
-	}
-	expectedIDBeginning := joinStatesIDs(baseStateNode, targetID)
-
+func (s *StateNode) getTarget(target Targeter, expectedIDBeginning string) (*StateNode, bool) {
 	for _, childStateNode := range s.States {
 		if stateNodeIDBeginsWithTargetID := strings.HasPrefix(childStateNode.id, expectedIDBeginning); stateNodeIDBeginsWithTargetID {
 			return childStateNode.resolveMostNestedInitialStateNode(), true
 		}
 
-		if matchingChildStateNode, ok := childStateNode.getTarget(t); ok {
+		if matchingChildStateNode, ok := childStateNode.getTarget(target, expectedIDBeginning); ok {
 			return matchingChildStateNode, true
 		}
 	}
@@ -809,7 +802,10 @@ func (machine *Machine) resolveStateNodeToEnter(stateNodeWithHandler *StateNode,
 			return nil, errors.New("parent state node is nil")
 		}
 
-		resolvedTargetStateNode, ok := parentStateNode.getTarget(target)
+		targetID := target.String()
+		expectedIDBeginning := joinStatesIDs(parentStateNode.id, targetID)
+
+		resolvedTargetStateNode, ok := parentStateNode.getTarget(target, expectedIDBeginning)
 		if !ok {
 			return nil, errors.New("could not resolve target")
 		}

--- a/machine.go
+++ b/machine.go
@@ -655,19 +655,13 @@ func (s *StateNode) validate(m *Machine) error {
 					continue
 				}
 
-				if _, hasTarget := s.getTarget(target); !hasTarget {
+				_, err := s.machine.resolveStateNodeToEnter(stateNode, transition)
+				if err != nil {
 					return &ErrInvalidTransitionNotImplementedWithDetails{
 						From:   stateNode,
 						Target: target,
 					}
 				}
-			}
-		}
-
-		// Recursively validate children states
-		if stateNode.isCompound() {
-			if err := stateNode.validate(m); err != nil {
-				return err
 			}
 		}
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -921,3 +921,36 @@ func TestResolvesChildTransitionsCorrectly(t *testing.T) {
 	assert.NotNil(validCompoundStateMachine)
 	assert.NoError(err)
 }
+
+func TestChildrenOfCompoundStateCanTransitionToSiblings(t *testing.T) {
+	assert := assert.New(t)
+
+	compoundStateMachine, err := brainy.NewMachine(brainy.StateNode{
+		Initial: CompoundState,
+
+		States: brainy.StateNodes{
+			CompoundState: &brainy.StateNode{
+				Initial: NestedAState,
+
+				States: brainy.StateNodes{
+					NestedAState: &brainy.StateNode{
+						On: brainy.Events{
+							GoToNestedBStateEvent: NestedBState,
+						},
+					},
+
+					NestedBState: &brainy.StateNode{},
+				},
+			},
+		},
+	})
+	assert.NotNil(compoundStateMachine)
+	assert.NoError(err)
+	assert.True(compoundStateMachine.Current().Matches(CompoundState, NestedAState))
+
+	nextState, err := compoundStateMachine.Send(GoToNestedBStateEvent)
+	assert.NotNil(nextState)
+	assert.NoError(err)
+	assert.True(nextState.Matches(CompoundState, NestedBState))
+	assert.True(compoundStateMachine.Current().Matches(CompoundState, NestedBState))
+}


### PR DESCRIPTION
Transitions between sibling states in a compound state did not work because the searched id was corrupted during the recursion.
Now the searched state id is built before the recursion and passed as parameter to each call.